### PR TITLE
Now works with with non-ascii characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ CamelCase is a Golang (Go) package to split the words of a camelcase type
 string into a slice of words. It can be used to convert a camelcase word (lower
 or upper case) into any type of word.
 
+## Splitting rules:
+
+1. If string is not valid UTF-8, return it without splitting as
+   single item array.
+2. Assign all unicode characters into one of 4 sets: lower case
+   letters, upper case letters, numbers, and all other characters.
+3. Iterate through characters of string, introducing splits
+   between adjacent characters that belong to different sets.
+4. Iterate through array of split strings, and if a given string
+   is upper case:
+   * if subsequent string is lower case:
+     * move last character of upper case string to beginning of
+       lower case string
+
 ## Install
 
 ```bash
@@ -24,17 +38,21 @@ check: [http://en.wikipedia.org/wiki/CamelCase](http://en.wikipedia.org/wiki/Cam
 Below are some example cases:
 
 ```
-lowercase =>       ["lowercase"]
-Class =>           ["Class"]
-MyClass =>         ["My", "Class"]
-MyC =>             ["My", "C"]
-HTML =>            ["HTML"]
-PDFLoader =>       ["PDF", "Loader"]
-AString =>         ["A", "String"]
-SimpleXMLParser => ["Simple", "XML", "Parser"]
-vimRPCPlugin =>    ["vim", "RPC", "Plugin"]
-GL11Version =>     ["GL", "11", "Version"]
-99Bottles =>       ["99", "Bottles"]
-May5 =>            ["May", "5"]
-BFG9000 =>         ["BFG", "9000"]
+"" =>                     []
+"lowercase" =>            ["lowercase"]
+"Class" =>                ["Class"]
+"MyClass" =>              ["My", "Class"]
+"MyC" =>                  ["My", "C"]
+"HTML" =>                 ["HTML"]
+"PDFLoader" =>            ["PDF", "Loader"]
+"AString" =>              ["A", "String"]
+"SimpleXMLParser" =>      ["Simple", "XML", "Parser"]
+"vimRPCPlugin" =>         ["vim", "RPC", "Plugin"]
+"GL11Version" =>          ["GL", "11", "Version"]
+"99Bottles" =>            ["99", "Bottles"]
+"May5" =>                 ["May", "5"]
+"BFG9000" =>              ["BFG", "9000"]
+"BöseÜberraschung" =>     ["Böse", "Überraschung"]
+"Two  spaces" =>          ["Two", "  ", "spaces"]
+"BadUTF8\xe2\xe2\xa1" =>  ["BadUTF8\xe2\xe2\xa1"]
 ```

--- a/camelcase_test.go
+++ b/camelcase_test.go
@@ -23,25 +23,25 @@ func ExampleSplit() {
 		"Two  spaces",
 		"BadUTF8\xe2\xe2\xa1",
 	} {
-		fmt.Printf("%#v\n", Split(c))
+		fmt.Printf("%#v => %#v\n", c, Split(c))
 	}
 
 	// Output:
-	// []string{}
-	// []string{"lowercase"}
-	// []string{"Class"}
-	// []string{"My", "Class"}
-	// []string{"My", "C"}
-	// []string{"HTML"}
-	// []string{"PDF", "Loader"}
-	// []string{"A", "String"}
-	// []string{"Simple", "XML", "Parser"}
-	// []string{"vim", "RPC", "Plugin"}
-	// []string{"GL", "11", "Version"}
-	// []string{"99", "Bottles"}
-	// []string{"May", "5"}
-	// []string{"BFG", "9000"}
-	// []string{"Böse", "Überraschung"}
-	// []string{"Two", "  ", "spaces"}
-	// []string{"BadUTF8\xe2\xe2\xa1"}
+	// "" => []string{}
+	// "lowercase" => []string{"lowercase"}
+	// "Class" => []string{"Class"}
+	// "MyClass" => []string{"My", "Class"}
+	// "MyC" => []string{"My", "C"}
+	// "HTML" => []string{"HTML"}
+	// "PDFLoader" => []string{"PDF", "Loader"}
+	// "AString" => []string{"A", "String"}
+	// "SimpleXMLParser" => []string{"Simple", "XML", "Parser"}
+	// "vimRPCPlugin" => []string{"vim", "RPC", "Plugin"}
+	// "GL11Version" => []string{"GL", "11", "Version"}
+	// "99Bottles" => []string{"99", "Bottles"}
+	// "May5" => []string{"May", "5"}
+	// "BFG9000" => []string{"BFG", "9000"}
+	// "BöseÜberraschung" => []string{"Böse", "Überraschung"}
+	// "Two  spaces" => []string{"Two", "  ", "spaces"}
+	// "BadUTF8\xe2\xe2\xa1" => []string{"BadUTF8\xe2\xe2\xa1"}
 }

--- a/camelcase_test.go
+++ b/camelcase_test.go
@@ -1,35 +1,47 @@
 package camelcase
 
-import (
-	"reflect"
-	"testing"
-)
+import "fmt"
 
-func TestSplit(t *testing.T) {
-	var testCases = []struct {
-		input  string
-		output []string
-	}{
-		{input: "", output: []string{}},
-		{input: "lowercase", output: []string{"lowercase"}},
-		{input: "Class", output: []string{"Class"}},
-		{input: "MyClass", output: []string{"My", "Class"}},
-		{input: "MyC", output: []string{"My", "C"}},
-		{input: "HTML", output: []string{"HTML"}},
-		{input: "PDFLoader", output: []string{"PDF", "Loader"}},
-		{input: "AString", output: []string{"A", "String"}},
-		{input: "SimpleXMLParser", output: []string{"Simple", "XML", "Parser"}},
-		{input: "vimRPCPlugin", output: []string{"vim", "RPC", "Plugin"}},
-		{input: "GL11Version", output: []string{"GL", "11", "Version"}},
-		{input: "99Bottles", output: []string{"99", "Bottles"}},
-		{input: "May5", output: []string{"May", "5"}},
-		{input: "BFG9000", output: []string{"BFG", "9000"}},
+func ExampleSplit() {
+
+	for _, c := range []string{
+		"",
+		"lowercase",
+		"Class",
+		"MyClass",
+		"MyC",
+		"HTML",
+		"PDFLoader",
+		"AString",
+		"SimpleXMLParser",
+		"vimRPCPlugin",
+		"GL11Version",
+		"99Bottles",
+		"May5",
+		"BFG9000",
+		"BöseÜberraschung",
+		"Two  spaces",
+		"BadUTF8\xe2\xe2\xa1",
+	} {
+		fmt.Printf("%#v\n", Split(c))
 	}
 
-	for _, c := range testCases {
-		res := Split(c.input)
-		if !reflect.DeepEqual(res, c.output) {
-			t.Errorf("input: '%s'\n\twant: %v\n\tgot : %v\n", c.input, c.output, res)
-		}
-	}
+	// Output:
+	// []string{}
+	// []string{"lowercase"}
+	// []string{"Class"}
+	// []string{"My", "Class"}
+	// []string{"My", "C"}
+	// []string{"HTML"}
+	// []string{"PDF", "Loader"}
+	// []string{"A", "String"}
+	// []string{"Simple", "XML", "Parser"}
+	// []string{"vim", "RPC", "Plugin"}
+	// []string{"GL", "11", "Version"}
+	// []string{"99", "Bottles"}
+	// []string{"May", "5"}
+	// []string{"BFG", "9000"}
+	// []string{"Böse", "Überraschung"}
+	// []string{"Two", "  ", "spaces"}
+	// []string{"BadUTF8\xe2\xe2\xa1"}
 }


### PR DESCRIPTION
@fatih When ranging over a string, the index does not necessarily increase by one byte with each iteration. For example, see https://play.golang.org/p/ATNWjRKS4f.

This means expressions like `rune(src[i-1])` are invalid if previous rune is more than one byte in size (it will represent previous byte, not previous rune).

This fix reads the string into an array of runes, and operates on that, rather than the underlying bytes of the string directly.

I've added a test to demonstrate the fix.

I've also switched the tests to being an example - so the split test cases don't need to be duplicated in the function comment, since they will be shown as an example in the go docs.
